### PR TITLE
Use stored tabs

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -25,6 +25,7 @@ export const Root = ({
     editorContent,
     setQuery: handleEditQuery,
     setHeaders: handleEditHeaders,
+    setOperationName: handleEditOperationName,
     setVariables: handleEditVariables,
   } = useGraphQLEditorContent(defaultQuery);
 
@@ -47,6 +48,7 @@ export const Root = ({
         variables={editorContent.variables}
         onEditQuery={handleEditQuery}
         onEditHeaders={handleEditHeaders}
+        onEditOperationName={handleEditOperationName}
         onEditVariables={handleEditVariables}
         plugins={[explorerPlugin]}
         shouldPersistHeaders={true}


### PR DESCRIPTION
Reuse GraphiQL's data saved to localStorage to restore current tab. This prevents unnecessary tab creation when simply opening GraphiQL with no query in the URL.