### PR TITLE
fix: react state bugs, new tab on existing non-blank or matching query

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
     "typescript": "5.2.2"
   },
   "dependencies": {
-    "@graphiql/plugin-explorer": "0.3.5",
-    "@graphiql/react": "0.20.1",
+    "@graphiql/plugin-explorer": "1.0.2-canary-5c561479.0",
+    "@graphiql/react": "0.20.2-canary-5c561479.0",
     "@graphiql/toolkit": "0.9.1",
-    "graphiql": "3.0.7",
+    "graphiql": "3.0.9-canary-5c561479.0",
     "graphql": "16.8.1",
     "lz-string": "1.5.0",
     "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
     "typescript": "5.2.2"
   },
   "dependencies": {
-    "@graphiql/plugin-explorer": "1.0.2-canary-5c561479.0",
-    "@graphiql/react": "0.20.2-canary-5c561479.0",
+    "@graphiql/plugin-explorer": "1.0.2",
+    "@graphiql/react": "0.20.2",
     "@graphiql/toolkit": "0.9.1",
-    "graphiql": "3.0.9-canary-5c561479.0",
+    "graphiql": "3.0.9",
     "graphql": "16.8.1",
     "lz-string": "1.5.0",
     "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
   },
   "dependencies": {
     "@graphiql/plugin-explorer": "0.3.5",
-    "@graphiql/react": "0.19.4",
+    "@graphiql/react": "0.20.1",
     "@graphiql/toolkit": "0.9.1",
-    "graphiql": "3.0.6",
+    "graphiql": "3.0.7",
     "graphql": "16.8.1",
     "lz-string": "1.5.0",
     "react": "18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,17 +9,17 @@ overrides:
 
 dependencies:
   '@graphiql/plugin-explorer':
-    specifier: 1.0.2-canary-5c561479.0
-    version: 1.0.2-canary-5c561479.0(@graphiql/react@0.20.2-canary-5c561479.0)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+    specifier: 1.0.2
+    version: 1.0.2(@graphiql/react@0.20.2)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
   '@graphiql/react':
-    specifier: 0.20.2-canary-5c561479.0
-    version: 0.20.2-canary-5c561479.0(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+    specifier: 0.20.2
+    version: 0.20.2(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
   '@graphiql/toolkit':
     specifier: 0.9.1
     version: 0.9.1(@types/node@20.8.8)(graphql@16.8.1)
   graphiql:
-    specifier: 3.0.9-canary-5c561479.0
-    version: 3.0.9-canary-5c561479.0(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+    specifier: 3.0.9
+    version: 3.0.9(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
   graphql:
     specifier: 16.8.1
     version: 16.8.1
@@ -271,23 +271,23 @@ packages:
     resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
     dev: false
 
-  /@graphiql/plugin-explorer@1.0.2-canary-5c561479.0(@graphiql/react@0.20.2-canary-5c561479.0)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-075ApySGHCxQxVI4ho7SGhTLuwn06Tf4fPXJHUU9QN+RgDaUIkzVDxNrFOCl3Tr3UmwwwbFlj3VSzxwEfRVDKg==}
+  /@graphiql/plugin-explorer@1.0.2(@graphiql/react@0.20.2)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-9j+kg2UjtLZD5EBmGjeWHkoVVxtbShYg2DzbUVebibnZYZM/iMBEF4vaccXJIAm5KaomIPLx0aoNs4LbODyc3Q==}
     peerDependencies:
-      '@graphiql/react': ^0.20.2-canary-5c561479.0
+      '@graphiql/react': ^0.20.2
       graphql: ^15.5.0 || ^16.0.0
       react: ^16.8.0 || ^17 || ^18
       react-dom: ^16.8.0 || ^17 || ^18
     dependencies:
-      '@graphiql/react': 0.20.2-canary-5c561479.0(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+      '@graphiql/react': 0.20.2(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
       graphiql-explorer: 0.9.0(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
       graphql: 16.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@graphiql/react@0.20.2-canary-5c561479.0(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-gkOeQeFkpgT6PFBgTWHnR7BDdsP6K/3H5PF96FMJYhc/DvTd3KdCeNFWbxUzstmOMt267j6O3CeQtAfQ2XWInw==}
+  /@graphiql/react@0.20.2(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-/crAUlM+4iVHyNHVdiZjsTEqfMXBHfjEvrMwCwTVig6YXmCAVuaxqkD7NlDtrrPQArLGkABmf1Nw7ObRpby5lg==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
       react: ^16.8.0 || ^17 || ^18
@@ -3639,14 +3639,14 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /graphiql@3.0.9-canary-5c561479.0(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-UoS5eJa37Oxx2eDoLykK8aaf6urxN2Ky68WbGyjkdNQZDbVI/RbXxBQRsh1JHKXTUUitlLaLdilI+6RKVpiXQA==}
+  /graphiql@3.0.9(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-xl9yEr6U4Wc3wmqvtP2sV2a3zGQkqrAMtU90x45QnpNT9MBgBn38HD1Yg5jExXxER65xmYWlGoYdAiD8v/dbEw==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
       react: ^16.8.0 || ^17 || ^18
       react-dom: ^16.8.0 || ^17 || ^18
     dependencies:
-      '@graphiql/react': 0.20.2-canary-5c561479.0(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+      '@graphiql/react': 0.20.2(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
       '@graphiql/toolkit': 0.9.1(@types/node@20.8.8)(graphql@16.8.1)
       graphql: 16.8.1
       graphql-language-service: 5.2.0(graphql@16.8.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,16 +10,16 @@ overrides:
 dependencies:
   '@graphiql/plugin-explorer':
     specifier: 0.3.5
-    version: 0.3.5(@graphiql/react@0.19.4)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+    version: 0.3.5(@graphiql/react@0.20.1)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
   '@graphiql/react':
-    specifier: 0.19.4
-    version: 0.19.4(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+    specifier: 0.20.1
+    version: 0.20.1(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
   '@graphiql/toolkit':
     specifier: 0.9.1
     version: 0.9.1(@types/node@20.8.8)(graphql@16.8.1)
   graphiql:
-    specifier: 3.0.6
-    version: 3.0.6(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+    specifier: 3.0.7
+    version: 3.0.7(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
   graphql:
     specifier: 16.8.1
     version: 16.8.1
@@ -271,7 +271,7 @@ packages:
     resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
     dev: false
 
-  /@graphiql/plugin-explorer@0.3.5(@graphiql/react@0.19.4)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
+  /@graphiql/plugin-explorer@0.3.5(@graphiql/react@0.20.1)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-oHn4cuH1uPWv70zy64mpG/x99BeFOFzGJ/tZXdx8wvb6c4aBMMCo4ouVnvNReVxE9N0KAwJfPvC6laWSbQ6lkQ==}
     peerDependencies:
       '@graphiql/react': ^0.19.4
@@ -279,15 +279,15 @@ packages:
       react: ^16.8.0 || ^17 || ^18
       react-dom: ^16.8.0 || ^17 || ^18
     dependencies:
-      '@graphiql/react': 0.19.4(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+      '@graphiql/react': 0.20.1(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
       graphiql-explorer: 0.9.0(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
       graphql: 16.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@graphiql/react@0.19.4(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-qg3N2Zeuq2+GDMZddz7K/ak1p5O56kKuLM/idOJZD+Lxbk2e8Eye3KWM24lJuuCi2gdvJuqPMfCdewLXrHhEkw==}
+  /@graphiql/react@0.20.1(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-BW9XwMui3hKNtOOG+kLl7cjQ3HP/cOWpqbaATDlwOmXubQ/Lo6OghthWZKLWPOk4sa0zMk+FX37UoTCVoEL0uA==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
       react: ^16.8.0 || ^17 || ^18
@@ -3639,14 +3639,14 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /graphiql@3.0.6(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-PuyAhRQibTrwT3RUKmwIGrJAB+M1gg+TAftmChjBqQW0n5WMFFvP5Wcr2NEikomY0s06+oKeUGhBU2iPrq+cSQ==}
+  /graphiql@3.0.7(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-/JRrBRnKwIwa3CtRQvu5N/TmysXk1ncBwbjyRgVvTklwDIxvoSZp3bsZkdPZ+4C1hpR9bYljozLYH+QZbUtnCw==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
       react: ^16.8.0 || ^17 || ^18
       react-dom: ^16.8.0 || ^17 || ^18
     dependencies:
-      '@graphiql/react': 0.19.4(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+      '@graphiql/react': 0.20.1(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
       '@graphiql/toolkit': 0.9.1(@types/node@20.8.8)(graphql@16.8.1)
       graphql: 16.8.1
       graphql-language-service: 5.2.0(graphql@16.8.1)
@@ -4564,7 +4564,7 @@ packages:
     resolution: {integrity: sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==}
     engines: {node: '>=13'}
     peerDependencies:
-      '@types/node': 20.8.8
+      '@types/node': '>=13'
     peerDependenciesMeta:
       '@types/node':
         optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,17 +9,17 @@ overrides:
 
 dependencies:
   '@graphiql/plugin-explorer':
-    specifier: 0.3.5
-    version: 0.3.5(@graphiql/react@0.20.1)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+    specifier: 1.0.2-canary-5c561479.0
+    version: 1.0.2-canary-5c561479.0(@graphiql/react@0.20.2-canary-5c561479.0)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
   '@graphiql/react':
-    specifier: 0.20.1
-    version: 0.20.1(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+    specifier: 0.20.2-canary-5c561479.0
+    version: 0.20.2-canary-5c561479.0(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
   '@graphiql/toolkit':
     specifier: 0.9.1
     version: 0.9.1(@types/node@20.8.8)(graphql@16.8.1)
   graphiql:
-    specifier: 3.0.7
-    version: 3.0.7(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+    specifier: 3.0.9-canary-5c561479.0
+    version: 3.0.9-canary-5c561479.0(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
   graphql:
     specifier: 16.8.1
     version: 16.8.1
@@ -271,23 +271,23 @@ packages:
     resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
     dev: false
 
-  /@graphiql/plugin-explorer@0.3.5(@graphiql/react@0.20.1)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-oHn4cuH1uPWv70zy64mpG/x99BeFOFzGJ/tZXdx8wvb6c4aBMMCo4ouVnvNReVxE9N0KAwJfPvC6laWSbQ6lkQ==}
+  /@graphiql/plugin-explorer@1.0.2-canary-5c561479.0(@graphiql/react@0.20.2-canary-5c561479.0)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-075ApySGHCxQxVI4ho7SGhTLuwn06Tf4fPXJHUU9QN+RgDaUIkzVDxNrFOCl3Tr3UmwwwbFlj3VSzxwEfRVDKg==}
     peerDependencies:
-      '@graphiql/react': ^0.19.4
+      '@graphiql/react': ^0.20.2-canary-5c561479.0
       graphql: ^15.5.0 || ^16.0.0
       react: ^16.8.0 || ^17 || ^18
       react-dom: ^16.8.0 || ^17 || ^18
     dependencies:
-      '@graphiql/react': 0.20.1(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+      '@graphiql/react': 0.20.2-canary-5c561479.0(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
       graphiql-explorer: 0.9.0(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
       graphql: 16.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@graphiql/react@0.20.1(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-BW9XwMui3hKNtOOG+kLl7cjQ3HP/cOWpqbaATDlwOmXubQ/Lo6OghthWZKLWPOk4sa0zMk+FX37UoTCVoEL0uA==}
+  /@graphiql/react@0.20.2-canary-5c561479.0(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-gkOeQeFkpgT6PFBgTWHnR7BDdsP6K/3H5PF96FMJYhc/DvTd3KdCeNFWbxUzstmOMt267j6O3CeQtAfQ2XWInw==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
       react: ^16.8.0 || ^17 || ^18
@@ -3639,14 +3639,14 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /graphiql@3.0.7(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-/JRrBRnKwIwa3CtRQvu5N/TmysXk1ncBwbjyRgVvTklwDIxvoSZp3bsZkdPZ+4C1hpR9bYljozLYH+QZbUtnCw==}
+  /graphiql@3.0.9-canary-5c561479.0(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-UoS5eJa37Oxx2eDoLykK8aaf6urxN2Ky68WbGyjkdNQZDbVI/RbXxBQRsh1JHKXTUUitlLaLdilI+6RKVpiXQA==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
       react: ^16.8.0 || ^17 || ^18
       react-dom: ^16.8.0 || ^17 || ^18
     dependencies:
-      '@graphiql/react': 0.20.1(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+      '@graphiql/react': 0.20.2-canary-5c561479.0(@codemirror/language@6.0.0)(@types/node@20.8.8)(@types/react-dom@18.2.14)(@types/react@18.2.31)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
       '@graphiql/toolkit': 0.9.1(@types/node@20.8.8)(graphql@16.8.1)
       graphql: 16.8.1
       graphql-language-service: 5.2.0(graphql@16.8.1)

--- a/src/CopyPlaygroundDialog.tsx
+++ b/src/CopyPlaygroundDialog.tsx
@@ -1,16 +1,17 @@
 import { Button, Dialog } from "@graphiql/react";
-import { useRef } from "react";
-import { useState } from "react";
+import { useRef, useState } from "react";
+
+import { editorContentToCurl } from "./curl";
 import { useEvent } from "./useEvent";
 import { editorContentToUrlFragment } from "./useGraphQLEditorContent";
-import { editorContentToCurl } from "./curl";
-import { EditorContent } from "./types";
+
+import type { EditorContent } from "./types";
 
 interface CopyPlaygroundDialogProps {
-  editorContent: EditorContent;
-  isOpen: boolean;
-  onClose: () => void;
-  endpoint: string;
+  readonly editorContent: EditorContent;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly endpoint: string;
 }
 
 export const CopyPlaygroundDialog = ({

--- a/src/CopyPlaygroundDialog.tsx
+++ b/src/CopyPlaygroundDialog.tsx
@@ -1,17 +1,16 @@
 import { Button, Dialog } from "@graphiql/react";
-import { useRef, useState } from "react";
-
-import { editorContentToCurl } from "./curl";
+import { useRef } from "react";
+import { useState } from "react";
 import { useEvent } from "./useEvent";
 import { editorContentToUrlFragment } from "./useGraphQLEditorContent";
-
-import type { EditorContent } from "./types";
+import { editorContentToCurl } from "./curl";
+import { EditorContent } from "./types";
 
 interface CopyPlaygroundDialogProps {
-  readonly editorContent: EditorContent;
-  readonly isOpen: boolean;
-  readonly onClose: () => void;
-  readonly endpoint: string;
+  editorContent: EditorContent;
+  isOpen: boolean;
+  onClose: () => void;
+  endpoint: string;
 }
 
 export const CopyPlaygroundDialog = ({

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -25,13 +25,7 @@ export const Root = ({
 }) => {
   const { fetcher, schema } = useFetcher(url);
 
-  const {
-    editorContent,
-    setQuery: handleEditQuery,
-    setHeaders: handleEditHeaders,
-    setOperationName: handleEditOperationName,
-    setVariables: handleEditVariables,
-  } = useGraphQLEditorContent(defaultQuery);
+  const editorContent = useGraphQLEditorContent(defaultQuery);
 
   const [isCopyPlaygroundDialogOpen, setIsCopyPlaygroundDialogOpen] = useState(false);
 
@@ -40,15 +34,6 @@ export const Root = ({
       <GraphiQL
         fetcher={fetcher}
         schema={schema}
-        query={editorContent.query}
-        defaultQuery={editorContent.query}
-        headers={editorContent.headers}
-        operationName={editorContent.operationName}
-        variables={editorContent.variables}
-        onEditQuery={handleEditQuery}
-        onEditHeaders={handleEditHeaders}
-        onEditOperationName={handleEditOperationName}
-        onEditVariables={handleEditVariables}
         plugins={[explorer]}
         shouldPersistHeaders={true}
         toolbar={{

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,5 +1,6 @@
 import "graphiql/graphiql.css";
-
+// import custom css to fix header, close icon, and input fields, a11y fixes coming soon
+import "@graphiql/plugin-explorer/dist/style.css";
 import "./style.css";
 
 import { explorerPlugin } from "@graphiql/plugin-explorer";

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -16,6 +16,31 @@ const explorer = explorerPlugin({
   showAttribution: false,
 });
 
+const CopyPlaygroundToolbarButton = ({
+  url,
+  defaultQuery,
+}: {
+  readonly url: string;
+  readonly defaultQuery?: string | undefined;
+}) => {
+  const editorContent = useGraphQLEditorContent(defaultQuery);
+
+  const [isCopyPlaygroundDialogOpen, setIsCopyPlaygroundDialogOpen] = useState(false);
+  return (
+    <>
+      <ToolbarButton onClick={() => setIsCopyPlaygroundDialogOpen(true)} label="Share Playground">
+        <ArrowUpOnSquareIcon />
+      </ToolbarButton>
+      <CopyPlaygroundDialog
+        isOpen={isCopyPlaygroundDialogOpen}
+        onClose={() => setIsCopyPlaygroundDialogOpen(false)}
+        editorContent={editorContent}
+        endpoint={url}
+      />
+    </>
+  );
+};
+
 export const Root = ({
   url,
   defaultQuery,
@@ -25,10 +50,6 @@ export const Root = ({
 }) => {
   const { fetcher, schema } = useFetcher(url);
 
-  const editorContent = useGraphQLEditorContent(defaultQuery);
-
-  const [isCopyPlaygroundDialogOpen, setIsCopyPlaygroundDialogOpen] = useState(false);
-
   return (
     <div className="graphiql-container">
       <GraphiQL
@@ -37,24 +58,9 @@ export const Root = ({
         plugins={[explorer]}
         shouldPersistHeaders={true}
         toolbar={{
-          additionalContent: (
-            <>
-              <ToolbarButton
-                onClick={() => setIsCopyPlaygroundDialogOpen(true)}
-                label="Share Playground"
-              >
-                <ArrowUpOnSquareIcon />
-              </ToolbarButton>
-            </>
-          ),
+          additionalContent: <CopyPlaygroundToolbarButton url={url} defaultQuery={defaultQuery} />,
         }}
       ></GraphiQL>
-      <CopyPlaygroundDialog
-        isOpen={isCopyPlaygroundDialogOpen}
-        onClose={() => setIsCopyPlaygroundDialogOpen(false)}
-        editorContent={editorContent}
-        endpoint={url}
-      />
     </div>
   );
 };

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -10,7 +10,7 @@ import { useState } from "react";
 import { ArrowUpOnSquareIcon } from "./ArrowUpOnSquareIcon";
 import { CopyPlaygroundDialog } from "./CopyPlaygroundDialog";
 import { useFetcher } from "./useFetcher";
-import { readFromUrl, useGraphQLEditorContent } from "./useGraphQLEditorContent";
+import { useGraphQLEditorContent } from "./useGraphQLEditorContent";
 
 const explorer = explorerPlugin({
   showAttribution: false,
@@ -18,12 +18,11 @@ const explorer = explorerPlugin({
 
 const CopyPlaygroundToolbarButton = ({
   url,
-  defaultQuery,
 }: {
   readonly url: string;
   readonly defaultQuery?: string | undefined;
 }) => {
-  const editorContent = useGraphQLEditorContent(defaultQuery);
+  const editorContent = useGraphQLEditorContent();
 
   const [isCopyPlaygroundDialogOpen, setIsCopyPlaygroundDialogOpen] = useState(false);
   return (
@@ -59,11 +58,9 @@ export const Root = ({
         shouldPersistHeaders={true}
         toolbar={{
           // additionalContent: <CopyPlaygroundToolbarButton url={url} defaultQuery={defaultQuery} />,
-          additionalComponent: () => (
-            <CopyPlaygroundToolbarButton url={url} defaultQuery={defaultQuery} />
-          ),
+          additionalComponent: () => <CopyPlaygroundToolbarButton url={url} />,
         }}
-        defaultQuery={defaultQuery}
+        defaultQuery={defaultQuery ?? ""}
       ></GraphiQL>
     </div>
   );

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -10,7 +10,7 @@ import { useState } from "react";
 import { ArrowUpOnSquareIcon } from "./ArrowUpOnSquareIcon";
 import { CopyPlaygroundDialog } from "./CopyPlaygroundDialog";
 import { useFetcher } from "./useFetcher";
-import { useGraphQLEditorContent } from "./useGraphQLEditorContent";
+import { readFromUrl, useGraphQLEditorContent } from "./useGraphQLEditorContent";
 
 const explorer = explorerPlugin({
   showAttribution: false,
@@ -58,8 +58,12 @@ export const Root = ({
         plugins={[explorer]}
         shouldPersistHeaders={true}
         toolbar={{
-          additionalContent: <CopyPlaygroundToolbarButton url={url} defaultQuery={defaultQuery} />,
+          // additionalContent: <CopyPlaygroundToolbarButton url={url} defaultQuery={defaultQuery} />,
+          additionalComponent: () => (
+            <CopyPlaygroundToolbarButton url={url} defaultQuery={defaultQuery} />
+          ),
         }}
+        defaultQuery={defaultQuery}
       ></GraphiQL>
     </div>
   );

--- a/src/useGraphQLEditorContent.tsx
+++ b/src/useGraphQLEditorContent.tsx
@@ -90,7 +90,9 @@ export const useGraphQLEditorContent = (defaultQuery?: string) => {
   }, []);
 
   return {
-    ...urlData,
+    query: context?.queryEditor?.getValue() || "",
+    variables: context?.variableEditor?.getValue() || "",
+    headers: context?.headerEditor?.getValue() || "",
     operationName: "",
   };
 };

--- a/src/useGraphQLEditorContent.tsx
+++ b/src/useGraphQLEditorContent.tsx
@@ -10,7 +10,6 @@ import { useEffect, useState } from "react";
 import { removeEmptyValues } from "./utils";
 
 import type { EditorContent } from "./types";
-import type { TabsState } from "@graphiql/react";
 
 type ShorterEditorContent = Record<
   (typeof longKeysToShortKeys)[keyof typeof longKeysToShortKeys],
@@ -39,7 +38,7 @@ export const editorContentToUrlFragment = (editorContent: EditorContent) => {
   return `saleor/${editorContentToSaveInUrl}`;
 };
 
-export const readFromUrl = (defaultQuery = ""): EditorContent | null => {
+const readFromUrl = (): EditorContent | null => {
   const editorContentFromUrl = window.location.hash.replace(/^#saleor\//, "");
 
   if (editorContentFromUrl.length > 0) {
@@ -47,7 +46,7 @@ export const readFromUrl = (defaultQuery = ""): EditorContent | null => {
       LzString.decompressFromEncodedURIComponent(editorContentFromUrl) || "{}",
     );
     return {
-      query: editorContent.q || defaultQuery,
+      query: editorContent.q,
       headers: editorContent.h || "",
       variables: editorContent.v || "",
       operationName: editorContent.o,
@@ -55,25 +54,24 @@ export const readFromUrl = (defaultQuery = ""): EditorContent | null => {
   }
   return null;
 };
-export const clearUrl = () => {
+const clearUrl = () => {
   const url = new URL(window.location.toString());
   url.hash = "";
   window.history.replaceState({}, "", url.toString());
 };
 
-export const useGraphQLEditorContent = (defaultQuery?: string) => {
+export const useGraphQLEditorContent = () => {
   const [currentQuery, setQuery] = useOperationsEditorState();
   const [, setVariables] = useVariablesEditorState();
   const [, setHeaders] = useHeadersEditorState();
   const [isInitialized, setIsInitialized] = useState(false);
   const context = useEditorContext();
-  const urlData = readFromUrl(defaultQuery);
+  const urlData = readFromUrl();
   useEffect(() => {
     if (!isInitialized && context?.queryEditor && urlData) {
       if (
         // if the current editor is currently empty or contains the exact default query (save whitespace)
-        currentQuery?.trim().length === 0 ||
-        currentQuery?.trim() === defaultQuery?.trim()
+        currentQuery?.trim().length === 0
       ) {
         setQuery(urlData.query);
         setVariables(urlData.variables);

--- a/src/useGraphQLEditorContent.tsx
+++ b/src/useGraphQLEditorContent.tsx
@@ -78,7 +78,7 @@ export const useGraphQLEditorContent = (defaultQuery?: string) => {
         setQuery(urlData.query);
         setVariables(urlData.variables);
         setHeaders(urlData.headers);
-      } else if (context.tabs?.length > 0) {
+      } else if (context.tabs?.length > 0 && urlData?.query !== currentQuery) {
         context.addTab();
         setQuery(urlData.query);
         setVariables(urlData.variables);


### PR DESCRIPTION
implements `@graphiql/react` hooks as a way to prevent undesired state propogation that causes bugs

this was the same solution to the issue for explorer plugin, so it appears to fix both the jumping cursor and operation name state issues!

NOTE: temporarily pinned to canary versions until release is ready

## Behavior:

1. if the URL contains a hash, and the current query is blank, or is the default query, it overrides the editor value.
2. if the above conditions aren't met, it adds a new tab and sets the value from the URL hash
2. it the current editor tab contains a query that's the same as the one in the URL, nothing happens
